### PR TITLE
refactor: rename card widget

### DIFF
--- a/lib/presenter/converter/views/conversion_view.dart
+++ b/lib/presenter/converter/views/conversion_view.dart
@@ -1,5 +1,6 @@
 import 'package:crypto_converter/app.dart';
 import 'package:crypto_converter/domain/converter/converter.dart';
+import 'package:crypto_converter/presenter/core/core.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:pull_to_refresh/pull_to_refresh.dart';
@@ -28,7 +29,7 @@ class _ConversionViewState extends State<ConversionView> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Converter', style: TextStyle(fontSize: 15)),
+        title: const Text(AppStrings.appName, style: TextStyle(fontSize: 15)),
       ),
       body: SafeArea(
         child: BlocListener<ConverterCubit, ConverterState>(
@@ -74,7 +75,7 @@ class _ConversionViewState extends State<ConversionView> {
           crossAxisCount: 2,
           children: [
             for (var exchange in exchangeRates)
-              CardWidget(
+              CryptoCardWidget(
                 code: exchange.cryptocurrency.code,
                 rate: exchange.rate.toStringAsFixed(2),
                 name: exchange.cryptocurrency.name,

--- a/lib/presenter/converter/widgets/card_widget.dart
+++ b/lib/presenter/converter/widgets/card_widget.dart
@@ -1,13 +1,13 @@
 import 'package:crypto_converter/app.dart';
 import 'package:flutter/material.dart';
 
-class CardWidget extends StatelessWidget {
+class CryptoCardWidget extends StatelessWidget {
   final String name;
   final IconData iconData;
   final String rate;
   final String code;
 
-  const CardWidget({
+  const CryptoCardWidget({
     Key? key,
     required this.code,
     required this.rate,
@@ -18,7 +18,6 @@ class CardWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Card(
-      color: Nord0,
       child: Column(
         mainAxisAlignment: MainAxisAlignment.spaceEvenly,
         children: [


### PR DESCRIPTION
- Rename card widget for better readability
- Update converter view to use app strings instead of hard coded string